### PR TITLE
Extend config from vue

### DIFF
--- a/src/vue-dragula.js
+++ b/src/vue-dragula.js
@@ -11,7 +11,7 @@ export default function (Vue) {
   let name = 'globalBag'
   let drake
 
-  Vue.vueDragula = {
+  Vue.prototype.vueDragula = {
     options: service.setOptions.bind(service),
     eventBus: service.eventBus
   }


### PR DESCRIPTION
Config is now extended from the vue allowing it to be accessible via components without the need to import anything.
